### PR TITLE
(General Service Tower Medium Section) Place top node at correct height for 10m section.

### DIFF
--- a/ModularLaunchPads/General_Bases/General-Service-Tower-Medium-Sec.cfg
+++ b/ModularLaunchPads/General_Bases/General-Service-Tower-Medium-Sec.cfg
@@ -183,7 +183,7 @@ MODULE
 		NODE
 		{
 			name = top
-			position = 0.0, 7.5, 0.0
+			position = 0.0, 10.0, 0.0
 		}
 	}
 


### PR DESCRIPTION
The General Service Tower Section (Medium) has an adjustable height.
If the maximum height is chosen, the top node is currently located at the wrong position.
This commit fixes the issue.